### PR TITLE
Heart Beat in DARK MODE

### DIFF
--- a/css/binaryCalculator.css
+++ b/css/binaryCalculator.css
@@ -28,9 +28,6 @@ body {
     top: 0;
     left: 0;
     z-index: -1;
-    /* Sends background behind the content */
-    animation: changeBackground 10s linear infinite;
-    /* Background color animation */
 }
 
 .title {
@@ -71,6 +68,7 @@ body {
     color: white;
     background-color: #607d8b;
     transition-duration: 0.4s;
+    text-align: center;
 }
 
 .button:hover {
@@ -85,9 +83,10 @@ body {
     margin: 5px;
     font-size: 25px;
     padding: 5px;
-    border: none;
+    border: 2px solid white;
     border-radius: 15px;
     background-color: #ffffff;
+    text-align: center;
 }
 
 .name {

--- a/css/darktheme.css
+++ b/css/darktheme.css
@@ -235,7 +235,61 @@ body {
     top: 2px;
     display: inline-block;
     text-align: center;
+    transition: color 1s;
     margin-right: 44px;
+}
+
+
+.footer:hover .heart {
+    color: #bf360c;
+    -webkit-animation: beat 0.35s infinite alternate;
+    -moz-animation: beat 0.35s infinite alternate;
+    -ms-animation: beat 0.35s infinite alternate;
+    -o-animation: beat 0.35s infinite alternate;
+    animation: beat 0.35s infinite alternate;
+    -webkit-transform-origin: center;
+    -moz-transform-origin: center;
+    -o-transform-origin: center;
+    -ms-transform-origin: center;
+    transform-origin: center;
+}
+
+@keyframes beat {
+    to {
+        -webkit-transform: scale(1.4);
+        -moz-transform: scale(1.4);
+        -o-transform: scale(1.4);
+        -ms-transform: scale(1.4);
+        transform: scale(1.4);
+    }
+}
+
+@-moz-keyframes beat {
+    to {
+        -moz-transform: scale(1.4);
+        transform: scale(1.4);
+    }
+}
+
+@-webkit-keyframes beat {
+    to {
+        -webkit-transform: scale(1.4);
+        transform: scale(1.4);
+    }
+}
+
+@-ms-keyframes beat {
+    to {
+        -ms-transform: scale(1.4);
+        transform: scale(1.4);
+    }
+}
+
+@-o-keyframes beat {
+    to {
+        -o-transform: scale(1.4);
+        transform: scale(1.4);
+    }
 }
 
 .social-media {

--- a/css/darktheme.css
+++ b/css/darktheme.css
@@ -134,6 +134,7 @@ body {
     background-color: #111;
     /* Dark background for input field */
     color: lime;
+    text-align: center;
     /* Neon green text color */
 }
 
@@ -145,7 +146,7 @@ body {
     position: absolute;
     color: lime;
     /* Neon green text color */
-    font-family: "Courier New", monospace;
+     font-family: Berlin Sans FB;
     font-style: oblique;
     font-size: large;
 }
@@ -235,10 +236,6 @@ body {
     display: inline-block;
     text-align: center;
     margin-right: 44px;
-}
-
-.made {
-    margin-right: 6px;
 }
 
 .social-media {

--- a/index.html
+++ b/index.html
@@ -30,11 +30,11 @@
             <span class="letter-l-9">l</span>
             <span class="letter-l-10">c</span>
             <span class="letter-l-11">u</span>
-            <span class="letter-l-12">l</span>
-            <span class="letter-l-13">a</span>
-            <span class="letter-l-14">t</span>
-            <span class="letter-l-15">o</span>
-            <span class="letter-l-16">r</span>
+            <span class="letter-l-9">l</span>
+            <span class="letter-l-8">a</span>
+            <span class="letter-l-12">t</span>
+            <span class="letter-l-13">o</span>
+            <span class="letter-l-14">r</span>
         </section>
         <form name="form">
             <div class="input-container">
@@ -98,12 +98,9 @@
                 <td><input class="button" type="button" value="Gray" onclick="binaryToGray()"></td>
                 <td><input class="button" type="button" value="Float" onclick="binaryToFloat()"></td>
                 <td><input class="button" type="button" value="Parity" onclick="calculateParityBit()"></td>
-                <td><input class="button" type="button" value="Square" onclick="squareRootBinary()"></td>                
-
+                <td><input class="button" type="button" value="Square" onclick="squareRootBinary()"></td>
             </tr>
             <tr>
-                <td><input class="button" type="button" value="," onclick="insert(',')"></td>
-
                 <td><input class="button" type="button" value="Factorial" onclick="factorialBinary()"></td>
             </tr>
             <div id="myModal" class="modal">


### PR DESCRIPTION
This PR adds heart beat animation in dark mode which was earlier not present.

Fixes #92 

Test:

- On Binary Calculator website switch to Dark-mode.
- Then navigate to Heart symbol on the right side of webpage next to "Made with" text.
- Notice that there is no heart beat animation as in light mode.

I have corrected the above issue.