### PR TITLE
All text are clearly visible now

### DIFF
--- a/css/binaryCalculator.css
+++ b/css/binaryCalculator.css
@@ -112,7 +112,8 @@
   .button {
     width: 75px;
     height: 75px;
-    font-size: 25px;
+    font-size: 15px;
+    font-weight: 700;
     margin: 2px;
     cursor: pointer;
     border-radius: 15px;
@@ -186,7 +187,7 @@
   
     .textview {
       width: 250px;
-      height: 40pxs
+      height: 40pxs;
       font-size: 20px;
     }
   

--- a/css/darktheme.css
+++ b/css/darktheme.css
@@ -49,7 +49,8 @@ body {
 .button {
     width: 75px;
     height: 75px;
-    font-size: 25px;
+    font-size: 15px;
+    font-weight: 700;
     margin: 2px;
     cursor: pointer;
     border-radius: 15px;


### PR DESCRIPTION
I have solved issue #93 
All the texts are clearly visible now 
None of the texts are hidden.
**These were the previous conditions without changing in dark and lite mode.**
<img width="339" alt="Screenshot 2024-10-15 at 4 39 42 PM" src="https://github.com/user-attachments/assets/d8c6ccca-23f6-4041-91b8-14b94066e12c">
<img width="339" alt="Screenshot 2024-10-15 at 4 39 21 PM" src="https://github.com/user-attachments/assets/94f9722d-6954-42c0-a3f4-6a7ccc851bc2">

**This is the current condition.**
<img width="339" alt="Screenshot 2024-10-15 at 6 54 19 PM" src="https://github.com/user-attachments/assets/a9358922-a1c6-42e8-aff0-e4fe7ecbe018">
<img width="339" alt="Screenshot 2024-10-15 at 6 54 09 PM" src="https://github.com/user-attachments/assets/b8f963e7-8e60-4879-80dc-f39c1b2dd995">


