### PR TITLE
Refactor calculateParityBit function to display the binary value

### DIFF
--- a/js/binaryCalculator.js
+++ b/js/binaryCalculator.js
@@ -433,9 +433,10 @@ function binaryToFloat() {
 function calculateParityBit() {
   let binary = document.form.textview.value;
   let ones = binary.split("").filter((bit) => bit === "1").length;
-  let parity = ones % 2 === 0 ? "Even" : "Odd";
-  alert(`Parity: ${parity}`);
+  let parityBit = ones % 2 === 0 ? "0" : "1";  
+  alert(`Binary: ${binary}, Parity bit: ${parityBit}`);
 }
+
 
 function squareRootBinary() {
   let binary = document.form.textview.value;


### PR DESCRIPTION
Modified the `calculateParityBit `  function to append the actual parity bit (0 or 1) based on the parity type you want (even or odd).
![image](https://github.com/user-attachments/assets/14562158-8d54-47f7-ae23-d2c47ba5ced1)
correct function implementation^
solves Issue #126 